### PR TITLE
chore: add bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "license": "ISC",
   "repository": "https://github.com/christophehurpeau/rollup-config-external-dependencies.git",
   "homepage": "https://github.com/christophehurpeau/rollup-config-external-dependencies",
+  "bugs": {
+    "url": "https://github.com/christophehurpeau/rollup-config-external-dependencies/issues"
+  },
   "type": "module",
   "packageManager": "yarn@4.6.0",
   "engines": {


### PR DESCRIPTION
## Summary

- Add `bugs.url` metadata to `package.json` pointing to this repository's GitHub issue tracker.
- Keep the change limited to npm package metadata; no runtime code, dependencies, exports, or generated files are changed.

## Validation

- `node -e 'const p=require("./package.json"); if (p.bugs?.url !== "https://github.com/christophehurpeau/rollup-config-external-dependencies/issues") throw new Error("bugs.url mismatch"); console.log(p.name, p.bugs.url)'`\n- `npm pack --dry-run --ignore-scripts --json`\n- `git diff --check`\n- `corepack yarn checks`\n- `corepack yarn test`